### PR TITLE
Fix bug (child data being repeated when coming up the stack to parent level)

### DIFF
--- a/demo/full_implementation.php
+++ b/demo/full_implementation.php
@@ -18,7 +18,7 @@ $dir = __DIR__.'/../vendor/twig/twig/lib/Twig';
 
 function createTree($dir) {
     $glob = glob($dir.'/*');
-    $nodes = [];
+    $nodes = array();
     foreach ($glob as $path) {
         if (is_dir($path)) {
             $nodes[basename($path)] = createTree($path);
@@ -30,7 +30,7 @@ function createTree($dir) {
     return $nodes;
 }
 
-echo $twig->render('full_implementation.twig', [
+echo $twig->render('full_implementation.twig', array(
     'files' => createTree($dir)
-]);
+));
 

--- a/demo/nav_menu_implementation.php
+++ b/demo/nav_menu_implementation.php
@@ -11,7 +11,7 @@ $twig->addExtension(new Fuz\Jordan\Twig\Extension\TreeExtension());
 class MenuItem {
     public $name;
     public $url;
-    public $children = [];
+    public $children = array();
     
     public function __construct($name, $url) {
         $this->name = $name;
@@ -19,7 +19,7 @@ class MenuItem {
     }
 }
 
-$menu = [];
+$menu = array();
 $menu[1] = new MenuItem('Home', '/');
 $menu[2] = new MenuItem('Products', '/products');
 $menu[2]->children[1] = new MenuItem('First Product', '/products/1');
@@ -36,4 +36,4 @@ $menu[3]->children[2] = new MenuItem('Downtown', '/locations/downtown');
 $menu[3]->children[3] = new MenuItem('Airport', '/locations/airport');
 $menu[4] = new MenuItem('About Us', '/about');
 
-echo $twig->render('nav_menu_implementation.twig', ['menu' => $menu]);
+echo $twig->render('nav_menu_implementation.twig', array('menu' => $menu));

--- a/demo/quick_implementation.php
+++ b/demo/quick_implementation.php
@@ -18,7 +18,7 @@ $dir = __DIR__.'/../vendor/twig/twig/lib/Twig';
 
 function createTree($dir) {
     $glob = glob($dir.'/*');
-    $nodes = [];
+    $nodes = array();
     foreach ($glob as $path) {
         if (is_dir($path)) {
             $nodes[basename($path)] = createTree($path);
@@ -30,6 +30,6 @@ function createTree($dir) {
     return $nodes;
 }
 
-echo $twig->render('quick_implementation.twig', [
+echo $twig->render('quick_implementation.twig', array(
     'files' => createTree($dir)
-]);
+));

--- a/src/Twig/Extension/TreeExtension.php
+++ b/src/Twig/Extension/TreeExtension.php
@@ -8,9 +8,9 @@ class TreeExtension extends \Twig_Extension
 {
     public function getTokenParsers()
     {
-        return [
+        return array(
             new TreeTokenParser(),
-        ];
+        );
     }
 
     public function getName() {

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -6,14 +6,14 @@ class TreeNode extends \Twig_Node
 {
     public function __construct(\Twig_Node_Expression_AssignName $keyTarget, \Twig_Node_Expression_AssignName $valueTarget, \Twig_Node_Expression $seq,  $as, array $data, $lineno, $tag)
     {
-        parent::__construct([
+        parent::__construct(array(
             'key_target'   => $keyTarget,
             'value_target' => $valueTarget,
             'seq'          => $seq,
-           ], [
+           ), array(
             'data'         => $data,
             'as'           => $as,
-           ], $lineno, $tag);
+           ), $lineno, $tag);
     }
 
     public function compile(\Twig_Compiler $compiler)
@@ -21,6 +21,10 @@ class TreeNode extends \Twig_Node
         $compiler
             ->addDebugInfo($this)
         ;
+
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            throw new \Exception('The {%tree%} Twig tag requires PHP version 5.4 or higher');
+        }
 
         // $tree_treeA = function($data) use (&$context, &$tree_treeA) {
         $compiler
@@ -41,12 +45,12 @@ class TreeNode extends \Twig_Node
 
         // initializing treeloop variable
         $compiler
-            ->write("\$context['treeloop'] = [\n")
+            ->write("\$context['treeloop'] = array(\n")
             ->write("  'parent' => \$context['_parent'],\n")
             ->write("  'index0' => 0,\n")
             ->write("  'index'  => 1,\n")
             ->write("  'first'  => true,\n")
-            ->write("];\n")
+            ->write(");\n")
             ->write("if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Countable)) {\n")
             ->indent()
             ->write("\$length = count(\$context['_seq']);\n")

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -27,7 +27,7 @@ class TreeNode extends \Twig_Node
             ->write("\$tree_")
             ->raw($this->getAttribute('as'))
             ->raw(" = ")
-            ->raw("function(\$data) use (&\$context, &\$tree_")
+            ->raw("function(\$data) use (\$context, &\$tree_")
             ->raw($this->getAttribute('as'))
             ->raw(") {\n")
             ->indent()

--- a/src/Twig/TokenParser/TreeTokenParser.php
+++ b/src/Twig/TokenParser/TreeTokenParser.php
@@ -31,16 +31,16 @@ class TreeTokenParser extends \Twig_TokenParser
         // %}
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        $data = [];
+        $data = array();
         while (true) {
 
             // backing up tag content
-            $data[] = [
+            $data[] = array(
                 'type' => 'body',
                 'node' => $this->parser->subparse(function(\Twig_Token $token) {
-                    return $token->test(['subtree', 'endtree']);
+                    return $token->test(array('subtree', 'endtree'));
                 })
-            ];
+            );
 
             // {% subtree
             if ($stream->next()->getValue() == 'subtree') {
@@ -58,11 +58,11 @@ class TreeTokenParser extends \Twig_TokenParser
                 $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
                 // backing up subtree details
-                $data[] = [
+                $data[] = array(
                     'type'  => 'subtree',
                     'with'  => $with,
                     'child' => $child,
-                ];
+                );
 
             // {% endtree
             } else {


### PR DESCRIPTION
Hi Alain. I think this tiny change (not passing in the `$context` by reference to the `$tree_...` closure) fixes a problem I was seeing where the last item of a parent level was not getting its markup outputted properly (instead the last of its children was having its markup outputted twice in a row, causing premature termination of `<ul>`, for example).

I hope this doesn't have other side effects... but it all seems to work for me.